### PR TITLE
Fix Build Bug

### DIFF
--- a/src/pty.cc
+++ b/src/pty.cc
@@ -16,6 +16,9 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
+#if defined(__APPLE__)
+  #include <sys/ioctl.h>
+#endif
 #include <fcntl.h>
 
 /* forkpty */


### PR DESCRIPTION
On OS X the forkpty module fails to build giving the error that ioctl() is not defined. On OS X ioctl is defined in sys/ioctl. I added a conditional include to ensure that it gets added.

NOTE: Don't have a freebsd (or other bsd) box in front of me, but I would assume it would require the same header to be included.
