### PR TITLE
Added ability to give the shell arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ JSON file. An example configuration file looks like:
   "port": 8080,
   "hostname": "127.0.0.1",
   "shell": "sh",
+  "shellArgs": ["arg1", "arg2"],
   "stylesheet": "./my_custom_stylesheet.css",
   "userStylesheet": "./user-stylesheet.css",
   "static": "./my_custom_static_directory/",

--- a/lib/config.js
+++ b/lib/config.js
@@ -17,6 +17,7 @@ var schema = {
   port: 8080,
   // hostname: '0.0.0.0',
   // shell: 'sh',
+  // shellArgs: ['arg1', 'arg2']
   // stylesheet: './style.css',
   // userStylesheet: './user-style.css',
   // static: './custom_static',

--- a/lib/tty.js
+++ b/lib/tty.js
@@ -29,6 +29,9 @@ var conf = require('./config');
 // Path to shell, or the process to execute in the terminal.
 var shellPath = conf.shell || process.env.SHELL || 'sh';
 
+// Arguments to shell, if they exist
+var shellArgs = conf.shellArgs || [];
+
 // $TERM
 var termName = 'xterm';
 termName = conf.term.termName || termName;
@@ -138,7 +141,7 @@ io.sockets.on('connection', function(socket) {
     var id = uid++
       , term;
 
-    term = pty.fork(shellPath, [], {
+    term = pty.fork(shellPath, shellArgs, {
       name: termName,
       cols: cols,
       rows: rows,


### PR DESCRIPTION
Specifically, I added an optional parameter to the config.json file. I need this feature because I need arguments to use the `ssh` shell.
