### PR TITLE
Middle mouse button paste in gecko

### DIFF
--- a/static/term.js
+++ b/static/term.js
@@ -341,7 +341,7 @@ Terminal.prototype.open = function() {
           break;
         }
       }
-      self.send(text.substr(fi, a2.length - a1.length + 1));
+			self.send(text.substr(fi, a2.length - a1.length + 1).replace(/^[\s\xa0]+|[\s\xa0]+$/g, '').replace(/\xa0|\s/g, ' '));
     }
     parent.removeEventListener('DOMCharacterDataModified',_handler, false);
     delete parent.dataset.ohtml;


### PR DESCRIPTION
This is a naive/lazy implementation for gecko middle mouse paste.

Gecko prohibits access to clipboard data in paste events. There are two solutions for this: either Flash or making diff to the content before the paste event and after it.

Because of how the terminal works (i.e. it expects text only, not html) a more simple solution would be to detect selection in the page and save the text of the selection and then use it in the case of paste event. It will not cover the case where the user wants to paste text from the clipboard, but is still useful because it can store selections from other windows/tabs in the same page.
