### PR TITLE
specify express version max

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "keywords": [ "tty", "terminal" ],
   "tags": [ "tty", "terminal" ],
   "dependencies": {
-    "express": ">= 2.5.8",
+    "express": ">= 2.5.8 < 3.x.x",
     "socket.io": ">= 0.8.7",
     "pty.js": ">= 0.1.2"
   }


### PR DESCRIPTION
I got an error with expressjs 3.0.0beta4:

```
events.js:101
    throw new Error('addListener only takes instances of Function');
          ^
Error: addListener only takes instances of Function
    at Server.<anonymous> (events.js:101:11)
    at new Server (http.js:1452:10)
    at Object.createServer (http.js:1469:10)
    at Server.<anonymous> (/home/charles/Repositories/mytty/node_modules/tty.js/node_modules/express/lib/application.js:531:21)
    at Object.<anonymous> (/home/charles/Repositories/mytty/index.js:9:5)
    at Module._compile (module.js:446:26)
    at Object..js (module.js:464:10)
    at Module.load (module.js:353:31)
    at Function._load (module.js:311:12)
    at Array.0 (module.js:484:10)
```

The `listen()` method has changed: https://github.com/visionmedia/express/blob/3.0.0beta4/lib/application.js#L508
