### PR TITLE
ability to change parentElement of a terminal instead of document.body

### DIFF
--- a/static/term.js
+++ b/static/term.js
@@ -179,6 +179,7 @@ function Terminal(cols, rows, handler) {
   this.savedX;
   this.savedY;
   this.savedCols;
+  this.parentElement = document.body;
 
   // stream
   this.readable = true;
@@ -340,7 +341,7 @@ Terminal.prototype.open = function() {
     this.children.push(div);
   }
 
-  document.body.appendChild(this.element);
+  this.parentElement.appendChild(this.element);
 
   this.refresh(0, this.rows - 1);
 


### PR DESCRIPTION
By default terminals get appended to the bottom of document.body. 

By setting the parentElement of the terminal before the open, you can control the position where the code gets inserted. 

`var term = new Terminal(80, 24);                         
term.parentElement = document.getElementById('terminal');
term.open();`
