### PR TITLE
check if element is a focusable element to send keys instead of terminal

### DIFF
--- a/static/term.js
+++ b/static/term.js
@@ -307,17 +307,32 @@ Terminal.prototype.focus = function() {
  * Global Events for key handling
  */
 
+
+function isFocusElement(ev) {
+  if (ev.srcElement instanceof HTMLInputElement) { return true; }
+  if (ev.srcElement instanceof HTMLButtonElement) { return true; }
+  if (ev.srcElement instanceof HTMLOptGroupElement) { return true; }
+  if (ev.srcElement instanceof HTMLOptionElement) { return true; }
+  if (ev.srcElement instanceof HTMLSelectElement) { return true; }
+  if (ev.srcElement instanceof HTMLTextAreaElement) { return true; }
+  return false;
+}
+
 Terminal.bindKeys = function() {
   if (Terminal.focus) return;
 
   // We could put an "if (Terminal.focus)" check
   // here, but it shouldn't be necessary.
   on(document, 'keydown', function(ev) {
-    return Terminal.focus.keyDown(ev);
+    if (!isFocusElement(ev)) {
+      return Terminal.focus.keyDown(ev);
+    }
   }, true);
 
   on(document, 'keypress', function(ev) {
-    return Terminal.focus.keyPress(ev);
+    if (!isFocusElement(ev)) {
+      return Terminal.focus.keyPress(ev);
+    }
   }, true);
 };
 


### PR DESCRIPTION
Currently term.js controls the keystrokes of the whole document.

Therefore input form elements, text areas etc... on the same document can not be typed.
By checking the type of element we can overcome this.
