### PR TITLE
undefined lines throwing errors

### DIFF
--- a/static/term.js
+++ b/static/term.js
@@ -788,6 +788,9 @@ Terminal.prototype.refresh = function(start, end) {
     row = y + this.ydisp;
 
     line = this.lines[row];
+    if (!line) {
+      continue;
+    }
     out = '';
 
     if (y === this.y


### PR DESCRIPTION
I was having trouble where the terminal was reporting a different line count then what actually existed. As a result, a exception was being thrown. This makes sure the line exists before trying to operate on it.
