### PR TITLE
blur() buttons (fix #49)

### DIFF
--- a/static/tty.js
+++ b/static/tty.js
@@ -75,12 +75,14 @@ tty.open = function() {
   if (open) {
     on(open, 'click', function() {
       new Window;
+      open.blur()
     });
   }
 
   if (lights) {
     on(lights, 'click', function() {
       tty.toggleLights();
+      lights.blur();
     });
   }
 


### PR DESCRIPTION
calls blur() on the 'open terminal' and 'light switch' buttons after clicking them
which prevents them from being activated again by the spacebar in some browsers
