### PR TITLE
fix SGR & DSR escape sequences (fix #59)

### DIFF
--- a/static/term.js
+++ b/static/term.js
@@ -1476,14 +1476,14 @@ Terminal.prototype.write = function(data) {
 
           // CSI Pm m  Character Attributes (SGR).
           case 'm':
-            if (!this.prefix)
+            if (!this.prefix) {
               this.charAttributes(this.params);
             }
             break;
 
           // CSI Ps n  Device Status Report (DSR).
           case 'n':
-            if (!this.prefix)
+            if (!this.prefix) {
               this.deviceStatus(this.params);
             }
             break;


### PR DESCRIPTION
^[[>##m and ^[[>##n are legal escape sequences, but were being parsed as if they were ^[[##m or ^[[##n.
Added a test for prefix character ('>' is the only legal one)

If the prefix char is present, ignores the control sequence, since that code isn't implemented.
