### PR TITLE
Specifying the config file at runtime

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -26,7 +26,7 @@ function readConfig(file) {
   if (file || options.config) {
     file = path.resolve(process.cwd(), file || options.config);
     dir = path.dirname(file);
-    json = options.config;
+    json = file;
   } else {
     dir = process.env.TTYJS_PATH || path.join(home, '.tty.js');
     json = path.join(dir, 'config.json');


### PR DESCRIPTION
I think it was not working to specify a file in the config.readConfig method
