### PR TITLE
pkill instead of subprocess execution for grep and awk (could use pgrep) and kill cmd

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -296,7 +296,7 @@ function killall() {
   };
 
   spawn('/bin/sh',
-    ['-c', 'kill $(ps ax | grep -v grep | grep tty.js | awk \'{print $1}\')'],
+    ['-c', 'pkill tty.js'],
     options);
 
   stop();


### PR DESCRIPTION
You can also use pgrep to grep for running processes and kill them
