### PR TITLE
Make server wait for client ACK before sending more data to be rendered.

### DIFF
--- a/lib/tty.js
+++ b/lib/tty.js
@@ -455,7 +455,11 @@ Session.prototype.handleCreate = function(cols, rows, func) {
   terms[id] = term;
 
   term.on('data', function(data) {
-    self.socket.emit('data', id, data);
+    term.pause();
+    self.socket.emit('data', id, data, function ack (res) {
+      term.resume();
+      return
+    });
   });
 
   term.on('close', function() {

--- a/static/tty.js
+++ b/static/tty.js
@@ -97,9 +97,10 @@ tty.open = function() {
     tty.emit('connect');
   });
 
-  tty.socket.on('data', function(id, data) {
+  tty.socket.on('data', function(id, data, func) {
     if (!tty.terms[id]) return;
     tty.terms[id].write(data);
+    func('ack');
   });
 
   tty.socket.on('kill', function(id) {


### PR DESCRIPTION
This will avoid buffer overflow, thereby giving the client the ability to actually kill spammy processes.

To give credit where credit's due: this problem (and solution) was outlined in [Issue #81](https://github.com/chjj/tty.js/issues/81) by @jayschwa