### PR TITLE
Fix issue with pty.js 0.2.7 having been removed from npm.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "express": "3.4.4",
     "socket.io": "0.9.16",
-    "pty.js": "0.2.7",
+    "pty.js": "0.2.7-1",
     "term.js": "0.0.4"
   },
   "engines": { "node": ">= 0.8.0" }


### PR DESCRIPTION
tty.js can no longer be installed due to pty.js 0.2.7 having been removed from npm so specify 0.2.7-1 directly (0.2.7-1 is counted as a prelease version, ie < 0.2.7 so ~0.2.7 or ^0.2.7 wouldn't work either)

It'd be great if you could release a new version that can be installed :)