### PR TITLE
Fixed pty.js package

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "express": "3.4.4",
     "socket.io": "0.9.16",
-    "pty.js": "0.2.7-1",
+    "pty.js": "^0.2.13",
     "term.js": "0.0.4"
   },
   "engines": { "node": ">= 0.8.0" }


### PR DESCRIPTION
Updated to latest version becouse previous version with '-' character ignored by npm and tried to install wrong version using 'npm install tty.js'
Fixes #146