### PR TITLE
Fixed Bug with shell and shellArgs being callbacks

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -102,7 +102,7 @@ function checkConfig(conf) {
   conf.hostname; // '0.0.0.0'
 
   // shell, process name
-  if (conf.shell && ~conf.shell.indexOf('/')) {
+  if (conf.shell && && typeof conf.shell !== 'function' && ~conf.shell.indexOf('/')) {
     conf.shell = path.resolve(conf.dir, conf.shell);
   }
   conf.shell = conf.shell || process.env.SHELL || 'sh';

--- a/lib/config.js
+++ b/lib/config.js
@@ -102,7 +102,7 @@ function checkConfig(conf) {
   conf.hostname; // '0.0.0.0'
 
   // shell, process name
-  if (conf.shell && && typeof conf.shell !== 'function' && ~conf.shell.indexOf('/')) {
+  if (conf.shell && typeof conf.shell !== 'function' && ~conf.shell.indexOf('/')) {
     conf.shell = path.resolve(conf.dir, conf.shell);
   }
   conf.shell = conf.shell || process.env.SHELL || 'sh';

--- a/lib/tty.js
+++ b/lib/tty.js
@@ -632,6 +632,7 @@ var slice = Array.prototype.slice;
 
 function sanitize(file) {
   if (!file) return '';
+  if (typeof file !== 'string') return file;
   file = file.split(' ')[0] || '';
   return path.basename(file) || '';
 }


### PR DESCRIPTION
I found this feature request and attempted to use it: https://github.com/chjj/tty.js/issues/62

I received some errors upon using the example provided. There are pieces of logic in the `config.js` and `tty.js` that expect `shell` and `shellArgs` to be of type `string`. I have updated the logic to not perform string operations when the two properties are functions.