### PR TITLE
Use node-pty instead of pty.js

### DIFF
--- a/lib/tty.js
+++ b/lib/tty.js
@@ -14,7 +14,7 @@ var path = require('path')
 
 var express = require('express')
   , io = require('socket.io')
-  , pty = require('pty.js')
+  , pty = require('node-pty')
   , term = require('term.js');
 
 var config = require('./config')

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "tags": ["tty", "terminal", "term", "xterm"],
   "dependencies": {
     "express": "3.4.4",
-    "socket.io": "0.9.16",
+    "socket.io": "2.1.1",
     "node-pty": ">= 0.7.7",
     "term.js": ">= 0.0.5"
   },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "express": "3.4.4",
     "socket.io": "0.9.16",
-    "pty.js": ">= 0.2.13",
+    "node-pty": ">= 0.7.7",
     "term.js": ">= 0.0.5"
   },
   "engines": { "node": ">= 0.8.0" }


### PR DESCRIPTION
This fork seems to compile fine in Windows compared to the current one.

See chjj/pty.js#185 for details.